### PR TITLE
Wangq13/deploy

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Imports:
     httr,
     jsonlite,
     magrittr,
-    readr
+    readr,
+    projmgr
 Suggests: 
     devtools,
     lifecycle,

--- a/R/setup.R
+++ b/R/setup.R
@@ -164,7 +164,13 @@ get_secret_email <- function() {
 #' @export
 get_token <- function(email_address = get_secret_email(),
                       secret = get_secret()) {
-  return(httr::content(httr::GET(url = httr::modify_url("https://analytic.tbportals.niaid.nih.gov/api/Token",
+  return(
+    ifelse(!is.raw(httr::content(httr::GET(url = httr::modify_url("https://analytic.tbportals.niaid.nih.gov/api/Token",
                                                         query = list(emailAddress = email_address,
-                                                                     secret = secret)))))
+                                                                     secret = secret))))),
+           httr::content(httr::GET(url = httr::modify_url("https://analytic.tbportals.niaid.nih.gov/api/Token",
+                                                          query = list(emailAddress = email_address,
+                                                                       secret = secret)))),
+           "Invalid credentials")
+    )
 }

--- a/tests/testthat/test-api_request.R
+++ b/tests/testthat/test-api_request.R
@@ -3,8 +3,8 @@ test_that("api request works", {
   INTERNET <- TRUE
 
   if (INTERNET) {
-    #TOKEN <- get_token()
-    TOKEN <- secret_make_key()
+    TOKEN <- get_token()
+    #TOKEN <- secret_make_key()
   }else{
     TOKEN <- "Invalid credentials"
   }

--- a/tests/testthat/test-api_request.R
+++ b/tests/testthat/test-api_request.R
@@ -1,15 +1,18 @@
 test_that("api request works", {
 
-  INTERNET <- TRUE
+  #INTERNET <- TRUE
+  INTERNET <- check_internet()
 
   if (INTERNET) {
     TOKEN <- get_token()
     #TOKEN <- secret_make_key()
   }else{
-    TOKEN <- "Invalid credentials"
+    #TOKEN <- "Invalid credentials"
+    TOKEN <- NA
   }
 
-  if (TOKEN != "Invalid credentials" & INTERNET) {
+  #if (TOKEN != "Invalid credentials" & INTERNET) {
+  if (!is.na(TOKEN) & INTERNET) {
     r <- tidy_depot_api(path = "Biochemistry", token = TOKEN)
     expect_equal(S3Class(r), "tidy_depot_api")
     expect_equal(S3Class(r$content), "data.frame")

--- a/tests/testthat/test-api_request.R
+++ b/tests/testthat/test-api_request.R
@@ -1,3 +1,5 @@
+library(projmgr)
+
 test_that("api request works", {
 
   #INTERNET <- TRUE

--- a/tests/testthat/test-api_request.R
+++ b/tests/testthat/test-api_request.R
@@ -9,12 +9,12 @@ test_that("api request works", {
     TOKEN <- get_token()
     #TOKEN <- secret_make_key()
   }else{
-    #TOKEN <- "Invalid credentials"
-    TOKEN <- NA
+    TOKEN <- "Invalid credentials"
+    #TOKEN <- NA
   }
 
-  #if (TOKEN != "Invalid credentials" & INTERNET) {
-  if (!is.na(TOKEN) & INTERNET) {
+  if (TOKEN != "Invalid credentials" & INTERNET) {
+  #if (!is.na(TOKEN) & INTERNET) {
     r <- tidy_depot_api(path = "Biochemistry", token = TOKEN)
     expect_equal(S3Class(r), "tidy_depot_api")
     expect_equal(S3Class(r$content), "data.frame")

--- a/tests/testthat/test-api_request.R
+++ b/tests/testthat/test-api_request.R
@@ -3,7 +3,8 @@ test_that("api request works", {
   INTERNET <- TRUE
 
   if (INTERNET) {
-    TOKEN <- get_token()
+    #TOKEN <- get_token()
+    TOKEN <- secret_make_key()
   }else{
     TOKEN <- "Invalid credentials"
   }

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -1,4 +1,5 @@
 devtools::load_all()
+library(projmgr)
 
 test_that("get_secret function works", {
   if (Sys.getenv("DEPOT_API_SECRET") == "") {
@@ -18,12 +19,14 @@ test_that("get_secret_email function works", {
 
 test_that("get_token function works", {
 
-  INTERNET <- TRUE
+  #INTERNET <- TRUE
+  INTERNET <- check_internet()
 
   .s <- get_secret()
   .e <- get_secret_email()
   if (INTERNET & .s != "" & .e != "") {
-    expect_equal(typeof(get_token()), "character")
+    #expect_equal(typeof(get_token()), "character")
+    expect_equal(typeof(get_token()), "raw")
     expect_equal(get_token(email_address = "not_valid@gmail.com",
                            secret = "not_valid"), "Invalid credentials")
   }else{

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -28,7 +28,7 @@ test_that("get_token function works", {
     #expect_equal(typeof(get_token()), "character")
     expect_equal(typeof(get_token()), "raw")
     expect_equal(get_token(email_address = "not_valid@gmail.com",
-                           secret = "not_valid"), "Invalid credentials")
+                       secret = "not_valid"), "Invalid credentials")
   }else{
     skip("API not available either due to no internet or incorrect credentials")
   }

--- a/tests/testthat/test-setup.R
+++ b/tests/testthat/test-setup.R
@@ -25,8 +25,8 @@ test_that("get_token function works", {
   .s <- get_secret()
   .e <- get_secret_email()
   if (INTERNET & .s != "" & .e != "") {
-    #expect_equal(typeof(get_token()), "character")
-    expect_equal(typeof(get_token()), "raw")
+    expect_equal(typeof(get_token()), "character")
+    #expect_equal(typeof(get_token()), "raw")
     expect_equal(get_token(email_address = "not_valid@gmail.com",
                        secret = "not_valid"), "Invalid credentials")
   }else{


### PR DESCRIPTION
get_token() used to create "Invalid credentials" for invalid token, but not anymore. Fixed it. 